### PR TITLE
Add volunteer registration form link to vol pages

### DIFF
--- a/old/en/vol.md
+++ b/old/en/vol.md
@@ -17,4 +17,13 @@ image_header: "/assets/images/headers/vol.svg"
 - Attend the conference for free, including TDC merchandise, meals during the event, and evening entertainment
 
 #### Interested in joining us or have questions?
-Send us an email at [frivillig@trondheimdc.no](mailto:frivillig@trondheimdc.no) with your name, email address, and phone number. We look forward to hearing from you!
+
+Fill in your contact information via the form below to register your interest:
+
+[Volunteer registration form](https://forms.gle/Eh1dA9AvEejJDAry8)
+
+We will start putting together the volunteer group in the autumn, and you will hear more from us then.
+
+Have questions about volunteering at TDC? You can contact us at [frivillig@trondheimdc.no](mailto:frivillig@trondheimdc.no).
+
+We look forward to hearing from you!

--- a/old/pages/vol.md
+++ b/old/pages/vol.md
@@ -18,4 +18,13 @@ image_header: "/assets/images/headers/vol.svg"
 - Delta gratis på konferansen, inkludert TDC-merch, mat under arrangementet og underholdning på kvelden  
 
 #### Interessert i å bli med, eller har du spørsmål?
-Send oss en e-post på [frivillig@trondheimdc.no](mailto:frivillig@trondheimdc.no?subject=Frivillig%20eller%20sp%C3%B8rsm%C3%A5l%20%E2%80%93%20TDC%202026) med navn, e-postadresse og telefonnummer. Vi gleder oss til å høre fra deg!
+
+Fyll ut din kontaktinformasjon via skjemaet under for å registrere din interesse:
+
+[Registreringsskjema for frivillige](https://forms.gle/Eh1dA9AvEejJDAry8)
+
+Vi starter arbeidet med å sette sammen frivilliggruppen til høsten, og du vil høre nærmere fra oss da.
+
+Har du spørsmål rundt det å være frivillig på TDC? Du kan kontakte oss på [frivillig@trondheimdc.no](mailto:frivillig@trondheimdc.no).
+
+Vi gleder oss til å høre fra deg!


### PR DESCRIPTION
## Summary
Replace email-based volunteer signup with a link to the Google Form registration.

Both Norwegian (/vol/) and English (/en/vol/) pages updated with:
- Link to the registration form: https://forms.gle/Eh1dA9AvEejJDAry8
- Info about volunteer group assembly timeline
- Email kept as fallback for questions

## Screenshots

### Norwegian (/vol/)
<img width="914" height="2757" alt="vol-no" src="https://github.com/user-attachments/assets/43d34177-4989-42be-8509-dd9b2d3828bc" />
### English (/en/vol/)
<img width="914" height="2781" alt="vol-en" src="https://github.com/user-attachments/assets/5a276190-7732-4cba-8301-cfb08e763476" />