### PR TITLE
Add GDPR section to volunteer page

### DIFF
--- a/old/en/vol.md
+++ b/old/en/vol.md
@@ -7,9 +7,9 @@ nav_active: vol
 image_header: "/assets/images/headers/vol.svg"
 ---
 
-### Become a volunteer at the city’s friendliest techn conference!
+### Become a volunteer at the city's friendliest tech conference!
 
-**As a volunteer, you’ll have a unique opportunity to:**
+**As a volunteer at TDC2026, you'll have a unique opportunity to:**
 - Meet industry and technology experts
 - Expand your network and build lasting connections
 - Learn about the latest trends in development, design, and technology
@@ -24,6 +24,16 @@ Fill in your contact information via the form below to register your interest:
 
 We will start putting together the volunteer group in the autumn, and you will hear more from us then.
 
-Have questions about volunteering at TDC? You can contact us at [frivillig@trondheimdc.no](mailto:frivillig@trondheimdc.no).
+#### Privacy and processing of personal data (GDPR)
+
+By submitting the form, you consent to your information being processed by the TDC program committee for the administration and selection of volunteers for TDC2026.
+
+The information will only be used in connection with volunteer work related to the conference and will not be shared with third parties without a legal basis.
+
+All personal data collected through this form will be deleted no later than 01.11.2026, unless otherwise required by law.
+
+You have the right to access, correct, and delete your own data in accordance with the General Data Protection Regulation (GDPR).
+
+Questions about the processing of personal data can be sent to [frivillig@trondheimdc.no](mailto:frivillig@trondheimdc.no).
 
 We look forward to hearing from you!

--- a/old/pages/vol.md
+++ b/old/pages/vol.md
@@ -8,14 +8,14 @@ image_header: "/assets/images/headers/vol.svg"
 
 ---
 
-### Bli frivillig på byens triveligste teknologikonferanse!  
+### Bli frivillig på byens triveligste teknologikonferanse!
 
-**Som frivillig får du en unik mulighet til å:**  
-- Møte bransje- og teknologieksperter  
-- Utvide nettverket ditt og bygge varige forbindelser  
-- Lære om de nyeste trendene innen utvikling, design og teknologi  
-- Få verdifull erfaring som kan styrke CV-en din  
-- Delta gratis på konferansen, inkludert TDC-merch, mat under arrangementet og underholdning på kvelden  
+**Som frivillig på TDC2026 får du en unik mulighet til å:**
+- Møte bransje- og teknologieksperter
+- Utvide nettverket ditt og bygge varige forbindelser
+- Lære om de nyeste trendene innen utvikling, design og teknologi
+- Få verdifull erfaring som kan styrke CV-en din
+- Delta gratis på konferansen, inkludert TDC-merch, mat under arrangementet og underholdning på kvelden
 
 #### Interessert i å bli med, eller har du spørsmål?
 
@@ -25,6 +25,16 @@ Fyll ut din kontaktinformasjon via skjemaet under for å registrere din interess
 
 Vi starter arbeidet med å sette sammen frivilliggruppen til høsten, og du vil høre nærmere fra oss da.
 
-Har du spørsmål rundt det å være frivillig på TDC? Du kan kontakte oss på [frivillig@trondheimdc.no](mailto:frivillig@trondheimdc.no).
+#### Personvern og behandling av personopplysninger (GDPR)
+
+Ved å sende inn skjemaet samtykker du til at opplysningene dine behandles av TDC programkomité for administrasjon og utvelgelse av frivillige til TDC2026.
+
+Opplysningene vil kun brukes i forbindelse med frivilligarbeid knyttet til konferansen og deles ikke med tredjeparter uten lovlig grunnlag.
+
+Alle personopplysninger som samles inn gjennom dette skjemaet slettes senest 01.11.2026, med mindre annet følger av lovpålagte krav.
+
+Du har rett til innsyn, retting og sletting av egne opplysninger i henhold til personvernforordningen (GDPR).
+
+Spørsmål om behandling av personopplysninger kan sendes til [frivillig@trondheimdc.no](mailto:frivillig@trondheimdc.no).
 
 Vi gleder oss til å høre fra deg!


### PR DESCRIPTION
Adds privacy/GDPR information to the volunteer page (both NO and EN). Also updates intro text to mention TDC2026 specifically and fixes typo in English heading.