### PR TITLE
Simplify speaker list to image+name with click-to-open bio modal

### DIFF
--- a/src/_includes/sections/speakers.njk
+++ b/src/_includes/sections/speakers.njk
@@ -11,44 +11,46 @@
         <ul class="speakers-grid" role="list">
           {% for speaker in sessionize.speakers %}
             <li class="speaker-item" id="speaker-{{ speaker.id }}">
-              <article class="speaker-card">
+              <button
+                type="button"
+                class="speaker-card"
+                data-speaker-open
+                data-speaker-name="{{ (speaker.firstName + ' ' + speaker.lastName) | escape }}"
+                data-speaker-image="{{ speaker.profilePicture | escape }}"
+                data-speaker-tagline="{{ speaker.tagLine | escape }}"
+                data-speaker-bio="{{ speaker.bio | escape }}"
+                data-speaker-twitter="{{ speaker.twitter | escape }}"
+                data-speaker-linkedin="{{ speaker.linkedIn | escape }}"
+                data-speaker-blog="{{ speaker.blog | escape }}"
+              >
                 {% if speaker.profilePicture %}
-                  <img 
-                    src="{{ speaker.profilePicture }}" 
-                    alt="{{ speaker.firstName }} {{ speaker.lastName }}"
+                  <img
+                    src="{{ speaker.profilePicture }}"
+                    alt=""
                     class="speaker-card__avatar"
                   />
                 {% endif %}
 
-                <h3 class="speaker-card__name">
+                <span class="speaker-card__name">
                   {{ speaker.firstName }} {{ speaker.lastName }}
-                </h3>
-
-                {% if speaker.tagLine %}
-                  <p class="speaker-card__title">{{ speaker.tagLine }}</p>
-                {% endif %}
-
-                {% if speaker.bio %}
-                  <p class="speaker-card__bio">{{ speaker.bio }}</p>
-                {% endif %}
-
-                {% if speaker.twitter or speaker.linkedIn or speaker.blog %}
-                  <div class="speaker-card__socials">
-                    {% if speaker.twitter %}
-                      <a href="https://twitter.com/{{ speaker.twitter }}" class="social-link">𝕏</a>
-                    {% endif %}
-                    {% if speaker.linkedIn %}
-                      <a href="{{ speaker.linkedIn }}" class="social-link">in</a>
-                    {% endif %}
-                    {% if speaker.blog %}
-                      <a href="{{ speaker.blog }}" class="social-link">🔗</a>
-                    {% endif %}
-                  </div>
-                {% endif %}
-              </article>
+                </span>
+              </button>
             </li>
           {% endfor %}
         </ul>
+
+        <dialog class="speaker-modal" id="speaker-description-modal" aria-labelledby="speaker-modal-name">
+          <div class="speaker-modal__header">
+            <button type="button" class="speaker-modal__close" data-speaker-close aria-label="Close">✕</button>
+          </div>
+          <div class="speaker-modal__content">
+            <img class="speaker-modal__avatar" id="speaker-modal-avatar" src="" alt="" />
+            <h3 class="speaker-modal__name" id="speaker-modal-name"></h3>
+            <p class="speaker-modal__tagline" id="speaker-modal-tagline"></p>
+            <p class="speaker-modal__bio" id="speaker-modal-bio"></p>
+            <div class="speaker-modal__socials" id="speaker-modal-socials"></div>
+          </div>
+        </dialog>
       {% else %}
         <p class="section__lead text-lead">{{ t.speakers.placeholder }}</p>
       {% endif %}

--- a/src/assets/css/04-components/speakers-sessionize.css
+++ b/src/assets/css/04-components/speakers-sessionize.css
@@ -5,7 +5,7 @@
 
 .speakers-grid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--spacing-4);
   list-style: none;
   padding: 0;
@@ -14,32 +14,41 @@
 
 @media (min-width: 768px) {
   .speakers-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }
 
 @media (min-width: 1024px) {
   .speakers-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(6, minmax(0, 1fr));
   }
 }
 
 .speaker-card {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   gap: var(--spacing-3);
-  height: 100%;
-  padding: var(--spacing-5);
+  width: 100%;
+  padding: var(--spacing-4);
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   box-shadow: 0 1px 1px rgb(0 0 0 / 0.04);
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: center;
+}
+
+.speaker-card:hover,
+.speaker-card:focus-visible {
+  border-color: var(--color-fg-brand);
 }
 
 .speaker-card__avatar {
-  width: 5rem;
-  height: 5rem;
+  width: 6rem;
+  height: 6rem;
   border-radius: 999px;
   object-fit: cover;
   border: 1px solid var(--color-border);
@@ -48,28 +57,100 @@
 
 .speaker-card__name {
   margin: 0;
-  font-size: var(--font-size-18);
+  font-size: var(--font-size-16);
   line-height: var(--line-height-tight);
   color: var(--color-fg-base);
 }
 
-.speaker-card__title {
+/* Speaker detail modal */
+.speaker-modal {
+  width: 100vw;
+  max-width: 100vw;
+  height: 100dvh;
+  max-height: 100dvh;
+  margin: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 0;
+  padding: var(--spacing-5);
+  background: var(--color-bg-surface);
+  color: var(--color-fg-base);
+}
+
+.speaker-modal::backdrop {
+  background: rgb(0 0 0 / 0.6);
+}
+
+.speaker-modal__header {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--spacing-4);
+}
+
+.speaker-modal__close {
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-fg-base);
+  border-radius: var(--radius-full);
+  width: 2rem;
+  height: 2rem;
+  cursor: pointer;
+}
+
+.speaker-modal__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-3);
+  text-align: center;
+  overflow: auto;
+  max-height: calc(100dvh - 6.5rem);
+}
+
+.speaker-modal__avatar {
+  width: 8rem;
+  height: 8rem;
+  border-radius: 999px;
+  object-fit: cover;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-base);
+}
+
+.speaker-modal__avatar[src=""] {
+  display: none;
+}
+
+.speaker-modal__name {
+  margin: 0;
+  font-size: var(--font-size-20);
+}
+
+.speaker-modal__tagline {
   margin: 0;
   color: var(--color-fg-brand);
   font-size: var(--font-size-14);
   font-weight: var(--font-weight-medium);
 }
 
-.speaker-card__bio {
-  margin: 0;
-  color: var(--color-fg-muted);
-  line-height: var(--line-height-relaxed);
+.speaker-modal__tagline:empty,
+.speaker-modal__bio:empty {
+  display: none;
 }
 
-.speaker-card__socials {
+.speaker-modal__bio {
+  margin: 0;
+  white-space: pre-line;
+  color: var(--color-fg-muted);
+  line-height: var(--line-height-relaxed);
+  text-align: left;
+}
+
+.speaker-modal__socials {
   display: flex;
   gap: var(--spacing-2);
-  margin-top: auto;
+}
+
+.speaker-modal__socials:empty {
+  display: none;
 }
 
 .social-link {
@@ -91,3 +172,19 @@
   border-color: var(--color-fg-brand);
   color: var(--color-fg-brand);
 }
+
+@media (min-width: 768px) {
+  .speaker-modal {
+    width: min(560px, calc(100vw - 2rem));
+    max-width: min(560px, calc(100vw - 2rem));
+    height: auto;
+    max-height: min(85dvh, 800px);
+    margin: auto;
+    border-radius: var(--radius-lg);
+  }
+
+  .speaker-modal__content {
+    max-height: calc(min(85dvh, 800px) - 6.5rem);
+  }
+}
+

--- a/src/assets/js/components/tdc-speaker-modal.js
+++ b/src/assets/js/components/tdc-speaker-modal.js
@@ -1,0 +1,99 @@
+class TdcSpeakerModal {
+  constructor() {
+    this.dialog = document.getElementById("speaker-description-modal");
+    this.avatarEl = document.getElementById("speaker-modal-avatar");
+    this.nameEl = document.getElementById("speaker-modal-name");
+    this.taglineEl = document.getElementById("speaker-modal-tagline");
+    this.bioEl = document.getElementById("speaker-modal-bio");
+    this.socialsEl = document.getElementById("speaker-modal-socials");
+
+    if (
+      !this.dialog ||
+      !this.avatarEl ||
+      !this.nameEl ||
+      !this.taglineEl ||
+      !this.bioEl ||
+      !this.socialsEl
+    )
+      return;
+
+    document.addEventListener("click", (event) => {
+      const openButton = event.target.closest("[data-speaker-open]");
+      if (openButton) {
+        this.open(openButton);
+        return;
+      }
+
+      const closeButton = event.target.closest("[data-speaker-close]");
+      if (closeButton) {
+        this.dialog.close();
+      }
+    });
+
+    this.dialog.addEventListener("click", (event) => {
+      const rect = this.dialog.getBoundingClientRect();
+      const insideDialog =
+        rect.top <= event.clientY &&
+        event.clientY <= rect.top + rect.height &&
+        rect.left <= event.clientX &&
+        event.clientX <= rect.left + rect.width;
+
+      if (!insideDialog) {
+        this.dialog.close();
+      }
+    });
+  }
+
+  open(button) {
+    const name = button.getAttribute("data-speaker-name") || "";
+    const image = button.getAttribute("data-speaker-image") || "";
+    const tagline = button.getAttribute("data-speaker-tagline") || "";
+    const bio = button.getAttribute("data-speaker-bio") || "";
+    const twitter = button.getAttribute("data-speaker-twitter") || "";
+    const linkedIn = button.getAttribute("data-speaker-linkedin") || "";
+    const blog = button.getAttribute("data-speaker-blog") || "";
+
+    this.nameEl.textContent = name;
+    this.avatarEl.src = image;
+    this.avatarEl.alt = name;
+    this.taglineEl.textContent = tagline;
+    this.bioEl.textContent = bio;
+    this.socialsEl.replaceChildren(...this.buildSocialLinks(twitter, linkedIn, blog));
+
+    if (typeof this.dialog.showModal === "function") {
+      this.dialog.showModal();
+    } else {
+      this.dialog.setAttribute("open", "");
+    }
+  }
+
+  buildSocialLinks(twitter, linkedIn, blog) {
+    const links = [];
+
+    if (twitter) {
+      links.push(this.createSocialLink(`https://twitter.com/${twitter}`, "𝕏"));
+    }
+    if (linkedIn) {
+      links.push(this.createSocialLink(linkedIn, "in"));
+    }
+    if (blog) {
+      links.push(this.createSocialLink(blog, "🔗"));
+    }
+
+    return links;
+  }
+
+  createSocialLink(href, label) {
+    const link = document.createElement("a");
+    link.href = href;
+    link.className = "social-link";
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.textContent = label;
+    return link;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  new TdcSpeakerModal();
+});

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -3,6 +3,7 @@ import "./components/tdc-nav.js";
 import "./components/tdc-section.js";
 import "./components/tdc-theme-toggle.js";
 import "./components/tdc-program-modal.js";
+import "./components/tdc-speaker-modal.js";
 // Clickable 8-bit duck mascot + easter eggs (lazy-loads the duck-mate engine).
 import "./components/tdc-duck.js";
 


### PR DESCRIPTION
## Summary
- simplify the speaker list view to show only the avatar and name for each speaker
- clicking a speaker (image or name) opens a modal with avatar, name, tagline, bio, and social links

## Technical changes
- `src/_includes/sections/speakers.njk`: speaker cards are now buttons carrying `data-speaker-*` attributes, plus a new `<dialog>` modal populated on open
- `src/assets/css/04-components/speakers-sessionize.css`: simplified card styles (denser grid) and new `.speaker-modal*` styles, responsive full-screen (mobile) / centered (desktop), mirroring the existing program modal
- new `src/assets/js/components/tdc-speaker-modal.js`: open/close/backdrop-click behavior, mirrors `tdc-program-modal.js`
- `src/assets/js/main.js`: imports the new component

## Notes
- branch: `feat/speaker-list-modal`
- base: `main`