### PR TITLE
Refresh speakers client-side from Sessionize on page load

### DIFF
--- a/src/_data/sessionize.js
+++ b/src/_data/sessionize.js
@@ -5,147 +5,17 @@
  * embed endpoints. We fetch those fragments at build time, parse out the pieces
  * we need, and expose structured data to the templates.
  *
+ * The parsing logic lives in assets/js/sessionize-client.js so it can be
+ * reused client-side (see components/tdc-speakers-refresh.js), which re-fetches
+ * the same endpoints in the browser to pick up speakers added after the last
+ * deploy without waiting for a rebuild.
  */
+import { fetchHtml, parseSessions, parseSpeakers, buildRooms } from "../assets/js/sessionize-client.js";
 
 const eventId = "xx320rm2";
 
 const sessionsUrl = `https://sessionize.com/api/v2/${eventId}/view/Sessions?under=True`;
 const speakersUrl = `https://sessionize.com/api/v2/${eventId}/view/Speakers?under=True`;
-
-function decodeEntities(value = "") {
-  return value
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, " ");
-}
-
-function stripHtml(value = "") {
-  return decodeEntities(
-    value
-      .replace(/<br\s*\/?>/gi, "\n")
-      .replace(/<\/p>/gi, "\n")
-      .replace(/<[^>]+>/g, " ")
-      .replace(/\s+\n/g, "\n")
-      .replace(/\n\s+/g, "\n")
-      .replace(/[ \t]{2,}/g, " ")
-      .trim()
-  );
-}
-
-async function fetchHtml(url, label) {
-  try {
-    console.log(`  Fetching ${label}...`);
-    const response = await fetch(url);
-    if (!response.ok) {
-      console.warn(`  ⚠️  Sessionize returned ${response.status} for ${label}`);
-      return "";
-    }
-    return await response.text();
-  } catch (error) {
-    console.warn(`  ⚠️  Sessionize fetch failed for ${label}:`, error.message);
-    return "";
-  }
-}
-
-function parseSessions(html) {
-  const sessions = [];
-  const openingTagPattern = /<li\b[^>]*id="sz-session-([^"]+)"[^>]*data-sessionid="([^"]+)"[^>]*class="([^"]*sz-session[^"]*)"[^>]*>/gi;
-  const matches = [...html.matchAll(openingTagPattern)];
-
-  for (let index = 0; index < matches.length; index++) {
-    const match = matches[index];
-    const [, domId, sessionId, className] = match;
-    const start = match.index ?? 0;
-    const end = index + 1 < matches.length ? matches[index + 1].index ?? html.length : html.length;
-    const body = html.slice(start, end);
-
-    const title = body.match(/<h3 class="sz-session__title">([\s\S]*?)<\/h3>/i)?.[1] ?? "";
-    const description = body.match(/<p class="sz-session__description">([\s\S]*?)<\/p>/i)?.[1] ?? "";
-    const roomMatch = body.match(/data-roomid="([^"]+)" class="sz-session__room">([\s\S]*?)<\/div>/i);
-    const timeMatch = body.match(/data-sztz="[^"]*\|[^"]*\|([^|]+)\|([^"]+)"/i);
-    const speakerIds = [...body.matchAll(/<li[^>]*data-speakerid="([^"]+)"[^>]*>[\s\S]*?<a[^>]*>([\s\S]*?)<\/a>/gi)].map(
-      (speakerMatch) => ({
-        id: speakerMatch[1],
-        name: stripHtml(speakerMatch[2]),
-      })
-    );
-
-    sessions.push({
-      id: sessionId || domId,
-      domId,
-      className,
-      title: stripHtml(title),
-      description: stripHtml(description),
-      startsAt: timeMatch?.[1] ?? "",
-      endsAt: timeMatch?.[2] ?? "",
-      roomId: roomMatch?.[1] ?? "",
-      roomName: stripHtml(roomMatch?.[2] ?? ""),
-      speakers: speakerIds.map((speaker) => speaker.id),
-    });
-  }
-
-  return sessions;
-}
-
-function parseSpeakers(html) {
-  const speakers = [];
-  const openingTagPattern = /<li\b[^>]*id="sz-speaker-([^"]+)"[^>]*data-speakerid="([^"]+)"[^>]*class="([^"]*sz-speaker[^"]*)"[^>]*>/gi;
-  const matches = [...html.matchAll(openingTagPattern)];
-
-  for (let index = 0; index < matches.length; index++) {
-    const match = matches[index];
-    const [, domId, speakerId, className] = match;
-    const start = match.index ?? 0;
-    const end = index + 1 < matches.length ? matches[index + 1].index ?? html.length : html.length;
-    const body = html.slice(start, end);
-
-    const photo = body.match(/<img[^>]*src="([^"]+)"[^>]*alt="([^"]*)"/i);
-    const name = body.match(/<h3 class="sz-speaker__name">([\s\S]*?)<\/h3>/i)?.[1] ?? "";
-    const tagline = body.match(/<h4 class="sz-speaker__tagline">([\s\S]*?)<\/h4>/i)?.[1] ?? "";
-    const bio = body.match(/<p class="sz-speaker__bio">([\s\S]*?)<\/p>/i)?.[1] ?? "";
-    const sessionIds = [...body.matchAll(/<li[^>]*data-sessionid="([^"]+)"[^>]*>[\s\S]*?<a[^>]*>([\s\S]*?)<\/a>/gi)].map(
-      (sessionMatch) => sessionMatch[1]
-    );
-
-    const [firstName, ...rest] = stripHtml(name).split(/\s+/);
-    const lastName = rest.join(" ");
-
-    speakers.push({
-      id: speakerId || domId,
-      domId,
-      className,
-      firstName: firstName || stripHtml(name),
-      lastName,
-      profilePicture: photo?.[1] ?? "",
-      profilePictureAlt: photo?.[2] ?? stripHtml(name),
-      tagLine: stripHtml(tagline),
-      bio: stripHtml(bio),
-      twitter: "",
-      linkedIn: "",
-      blog: "",
-      sessions: sessionIds,
-    });
-  }
-
-  return speakers;
-}
-
-function buildRooms(sessions) {
-  const rooms = new Map();
-  for (const session of sessions) {
-    if (!session.roomId) continue;
-    if (!rooms.has(session.roomId)) {
-      rooms.set(session.roomId, {
-        id: session.roomId,
-        name: session.roomName || session.roomId,
-      });
-    }
-  }
-  return [...rooms.values()];
-}
 
 export default async function () {
   console.log("🎤 Fetching Sessionize data from HTML fragments...");

--- a/src/_includes/sections/speakers.njk
+++ b/src/_includes/sections/speakers.njk
@@ -6,7 +6,7 @@
     </header>
 
     {# Custom speaker wall using Sessionize API data #}
-    <div class="speakers-wall">
+    <div class="speakers-wall" data-sessionize-event-id="{{ site.sessionizeEventId }}">
       {% if sessionize.speakers and sessionize.speakers.length > 0 %}
         <ul class="speakers-grid" role="list">
           {% for speaker in sessionize.speakers %}

--- a/src/assets/js/components/tdc-speakers-refresh.js
+++ b/src/assets/js/components/tdc-speakers-refresh.js
@@ -1,0 +1,106 @@
+// Client-side speaker refresh — re-fetches Sessionize directly from the
+// browser (its embed endpoints send `Access-Control-Allow-Origin: *`) and
+// rebuilds the speaker grid if the call succeeds. This means a speaker added
+// in Sessionize after the last deploy still shows up for visitors without
+// anyone needing to trigger a rebuild.
+//
+// Scope: this only refreshes on top of an already-rendered static grid (the
+// common case — some speakers already exist at build time). If the static
+// build has zero speakers, it leaves the placeholder copy alone rather than
+// building a grid from scratch client-side.
+//
+// Shares its HTML-parsing logic with _data/sessionize.js (the build-time
+// fetch) via sessionize-client.js so both stay in sync.
+
+import { fetchHtml, parseSessions, parseSpeakers } from "../sessionize-client.js";
+
+function buildSpeakerCard(speaker, sessions, detailsLabel) {
+  const li = document.createElement("li");
+  li.className = "speaker-item";
+  li.id = `speaker-${speaker.id}`;
+
+  const fullName = `${speaker.firstName} ${speaker.lastName}`.trim();
+  const talkId = speaker.sessions?.[0];
+  const talk = talkId ? sessions.find((session) => session.id === talkId) : null;
+
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "speaker-card";
+  button.setAttribute("data-speaker-open", "");
+  button.setAttribute("data-speaker-name", fullName);
+  button.setAttribute("data-speaker-image", speaker.profilePicture || "");
+  button.setAttribute("data-speaker-tagline", speaker.tagLine || "");
+  button.setAttribute("data-speaker-bio", speaker.bio || "");
+  button.setAttribute("data-speaker-twitter", speaker.twitter || "");
+  button.setAttribute("data-speaker-linkedin", speaker.linkedIn || "");
+  button.setAttribute("data-speaker-blog", speaker.blog || "");
+  button.setAttribute("data-speaker-talk-title", talk?.title || "");
+  button.setAttribute("data-speaker-talk-description", talk?.description || "");
+
+  if (speaker.profilePicture) {
+    const img = document.createElement("img");
+    img.src = speaker.profilePicture;
+    img.alt = "";
+    img.className = "speaker-card__avatar";
+    button.appendChild(img);
+  }
+
+  const nameEl = document.createElement("span");
+  nameEl.className = "speaker-card__name";
+  nameEl.textContent = fullName;
+  button.appendChild(nameEl);
+
+  if (talk) {
+    const talkEl = document.createElement("span");
+    talkEl.className = "speaker-card__talk";
+    talkEl.textContent = talk.title;
+    button.appendChild(talkEl);
+  }
+
+  const moreEl = document.createElement("span");
+  moreEl.className = "speaker-card__more";
+  moreEl.textContent = detailsLabel;
+  button.appendChild(moreEl);
+
+  li.appendChild(button);
+  return li;
+}
+
+async function refreshSpeakers() {
+  const wall = document.querySelector(".speakers-wall[data-sessionize-event-id]");
+  const grid = wall?.querySelector(".speakers-grid");
+  if (!wall || !grid) return;
+
+  const eventId = wall.getAttribute("data-sessionize-event-id");
+  if (!eventId) return;
+
+  const sessionsUrl = `https://sessionize.com/api/v2/${eventId}/view/Sessions?under=True`;
+  const speakersUrl = `https://sessionize.com/api/v2/${eventId}/view/Speakers?under=True`;
+
+  try {
+    const [sessionsHtml, speakersHtml] = await Promise.all([
+      fetchHtml(sessionsUrl, "Sessionize sessions (client refresh)"),
+      fetchHtml(speakersUrl, "Sessionize speakers (client refresh)"),
+    ]);
+
+    const sessions = parseSessions(sessionsHtml);
+    const speakers = parseSpeakers(speakersHtml);
+
+    // Nothing usable came back — keep showing the statically-built list.
+    if (speakers.length === 0) return;
+
+    const detailsLabel = grid.querySelector(".speaker-card__more")?.textContent || "";
+    const newGrid = document.createElement("ul");
+    newGrid.className = "speakers-grid";
+    newGrid.setAttribute("role", "list");
+    for (const speaker of speakers) {
+      newGrid.appendChild(buildSpeakerCard(speaker, sessions, detailsLabel));
+    }
+
+    grid.replaceWith(newGrid);
+  } catch (error) {
+    console.warn("Speaker refresh skipped:", error);
+  }
+}
+
+document.addEventListener("DOMContentLoaded", refreshSpeakers);

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -7,6 +7,8 @@ import "./components/tdc-speaker-modal.js";
 import "./components/tdc-faq.js";
 // Clickable 8-bit duck mascot + easter eggs (lazy-loads the duck-mate engine).
 import "./components/tdc-duck.js";
+// Re-fetches Sessionize client-side so newly added speakers show up without a rebuild.
+import "./components/tdc-speakers-refresh.js";
 
 // Shuffle partner logos on load so no single partner is always first.
 document.addEventListener("DOMContentLoaded", () => {

--- a/src/assets/js/sessionize-client.js
+++ b/src/assets/js/sessionize-client.js
@@ -1,0 +1,143 @@
+/**
+ * Shared Sessionize HTML-fragment parsing helpers.
+ *
+ * Pure, platform-agnostic (no Node- or browser-only APIs), so the exact same
+ * logic can run at Eleventy build time (_data/sessionize.js) and again in the
+ * browser (components/tdc-speakers-refresh.js) to pick up speakers/sessions
+ * added in Sessionize after the last deploy.
+ */
+
+export function decodeEntities(value = "") {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ");
+}
+
+export function stripHtml(value = "") {
+  return decodeEntities(
+    value
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/p>/gi, "\n")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/\s+\n/g, "\n")
+      .replace(/\n\s+/g, "\n")
+      .replace(/[ \t]{2,}/g, " ")
+      .trim()
+  );
+}
+
+export async function fetchHtml(url, label) {
+  try {
+    console.log(`  Fetching ${label}...`);
+    const response = await fetch(url);
+    if (!response.ok) {
+      console.warn(`  ⚠️  Sessionize returned ${response.status} for ${label}`);
+      return "";
+    }
+    return await response.text();
+  } catch (error) {
+    console.warn(`  ⚠️  Sessionize fetch failed for ${label}:`, error.message);
+    return "";
+  }
+}
+
+export function parseSessions(html) {
+  const sessions = [];
+  const openingTagPattern = /<li\b[^>]*id="sz-session-([^"]+)"[^>]*data-sessionid="([^"]+)"[^>]*class="([^"]*sz-session[^"]*)"[^>]*>/gi;
+  const matches = [...html.matchAll(openingTagPattern)];
+
+  for (let index = 0; index < matches.length; index++) {
+    const match = matches[index];
+    const [, domId, sessionId, className] = match;
+    const start = match.index ?? 0;
+    const end = index + 1 < matches.length ? matches[index + 1].index ?? html.length : html.length;
+    const body = html.slice(start, end);
+
+    const title = body.match(/<h3 class="sz-session__title">([\s\S]*?)<\/h3>/i)?.[1] ?? "";
+    const description = body.match(/<p class="sz-session__description">([\s\S]*?)<\/p>/i)?.[1] ?? "";
+    const roomMatch = body.match(/data-roomid="([^"]+)" class="sz-session__room">([\s\S]*?)<\/div>/i);
+    const timeMatch = body.match(/data-sztz="[^"]*\|[^"]*\|([^|]+)\|([^"]+)"/i);
+    const speakerIds = [...body.matchAll(/<li[^>]*data-speakerid="([^"]+)"[^>]*>[\s\S]*?<a[^>]*>([\s\S]*?)<\/a>/gi)].map(
+      (speakerMatch) => ({
+        id: speakerMatch[1],
+        name: stripHtml(speakerMatch[2]),
+      })
+    );
+
+    sessions.push({
+      id: sessionId || domId,
+      domId,
+      className,
+      title: stripHtml(title),
+      description: stripHtml(description),
+      startsAt: timeMatch?.[1] ?? "",
+      endsAt: timeMatch?.[2] ?? "",
+      roomId: roomMatch?.[1] ?? "",
+      roomName: stripHtml(roomMatch?.[2] ?? ""),
+      speakers: speakerIds.map((speaker) => speaker.id),
+    });
+  }
+
+  return sessions;
+}
+
+export function parseSpeakers(html) {
+  const speakers = [];
+  const openingTagPattern = /<li\b[^>]*id="sz-speaker-([^"]+)"[^>]*data-speakerid="([^"]+)"[^>]*class="([^"]*sz-speaker[^"]*)"[^>]*>/gi;
+  const matches = [...html.matchAll(openingTagPattern)];
+
+  for (let index = 0; index < matches.length; index++) {
+    const match = matches[index];
+    const [, domId, speakerId, className] = match;
+    const start = match.index ?? 0;
+    const end = index + 1 < matches.length ? matches[index + 1].index ?? html.length : html.length;
+    const body = html.slice(start, end);
+
+    const photo = body.match(/<img[^>]*src="([^"]+)"[^>]*alt="([^"]*)"/i);
+    const name = body.match(/<h3 class="sz-speaker__name">([\s\S]*?)<\/h3>/i)?.[1] ?? "";
+    const tagline = body.match(/<h4 class="sz-speaker__tagline">([\s\S]*?)<\/h4>/i)?.[1] ?? "";
+    const bio = body.match(/<p class="sz-speaker__bio">([\s\S]*?)<\/p>/i)?.[1] ?? "";
+    const sessionIds = [...body.matchAll(/<li[^>]*data-sessionid="([^"]+)"[^>]*>[\s\S]*?<a[^>]*>([\s\S]*?)<\/a>/gi)].map(
+      (sessionMatch) => sessionMatch[1]
+    );
+
+    const [firstName, ...rest] = stripHtml(name).split(/\s+/);
+    const lastName = rest.join(" ");
+
+    speakers.push({
+      id: speakerId || domId,
+      domId,
+      className,
+      firstName: firstName || stripHtml(name),
+      lastName,
+      profilePicture: photo?.[1] ?? "",
+      profilePictureAlt: photo?.[2] ?? stripHtml(name),
+      tagLine: stripHtml(tagline),
+      bio: stripHtml(bio),
+      twitter: "",
+      linkedIn: "",
+      blog: "",
+      sessions: sessionIds,
+    });
+  }
+
+  return speakers;
+}
+
+export function buildRooms(sessions) {
+  const rooms = new Map();
+  for (const session of sessions) {
+    if (!session.roomId) continue;
+    if (!rooms.has(session.roomId)) {
+      rooms.set(session.roomId, {
+        id: session.roomId,
+        name: session.roomName || session.roomId,
+      });
+    }
+  }
+  return [...rooms.values()];
+}


### PR DESCRIPTION
## Problem

The speaker wall is built at Eleventy build time from Sessionize's HTML embed endpoints. Speakers added in Sessionize after the last deploy (e.g. a new keynote) don't show up on the live site until the next rebuild - and this repo currently only rebuilds on a push to `main` or a manual workflow dispatch, not on a schedule.

## Fix

Sessionize's embed endpoints send `Access-Control-Allow-Origin: *`, so the browser can fetch them directly. This adds a client-side refresh on top of the existing static build:

- Extracted the HTML-fragment parsing logic into `src/assets/js/sessionize-client.js`, shared between build time (`src/_data/sessionize.js`) and the browser. No Node- or browser-only APIs, so the exact same parsing runs in both places.
- New `src/assets/js/components/tdc-speakers-refresh.js` re-fetches Sessionize on page load and rebuilds the speaker grid using DOM APIs (`createElement`/`setAttribute`/`textContent`, never `innerHTML`) if the call succeeds.
- If the fetch fails or returns no speakers, nothing changes - the statically-built list stays as a fallback (keeps SEO/no-JS/first-paint behavior intact).
- Only refreshes on top of an already-rendered static grid (the common case). No change needed to the existing speaker-modal component since it reads `data-*` attributes via event delegation at click time.

## Testing

- `bun run build` succeeds.
- Manually verified end-to-end: rebuilt the site, stripped a speaker's card from the built HTML to simulate a stale deploy, served the static output, loaded it in a browser - the missing speaker reappeared automatically after the client-side refresh ran, and clicking their card opened the modal with the correct bio/photo/talk.
