### PR TITLE
Track duck and speaker clicks in Matomo

### DIFF
--- a/src/_includes/sections/speakers.njk
+++ b/src/_includes/sections/speakers.njk
@@ -19,6 +19,7 @@
                 type="button"
                 class="speaker-card"
                 data-speaker-open
+                data-speaker-id="{{ speaker.id | escape }}"
                 data-speaker-name="{{ (speaker.firstName + ' ' + speaker.lastName) | escape }}"
                 data-speaker-image="{{ speaker.profilePicture | escape }}"
                 data-speaker-tagline="{{ speaker.tagLine | escape }}"

--- a/src/assets/js/components/tdc-duck.js
+++ b/src/assets/js/components/tdc-duck.js
@@ -152,6 +152,7 @@ export class TdcDuck extends HTMLElement {
     this.duck.addEventListener('click', (e) => {
       e.stopPropagation();
       this.quack();
+      this.trackDuckClick();
       this.trackClicks();
     });
 
@@ -167,6 +168,7 @@ export class TdcDuck extends HTMLElement {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         this.quack();
+        this.trackDuckClick();
         this.trackClicks();
       }
     });
@@ -222,6 +224,11 @@ export class TdcDuck extends HTMLElement {
     setTimeout(() => {
       this.duck.classList.remove('is-spinning');
     }, 800);
+  }
+
+  trackDuckClick() {
+    const tracker = window._paq = window._paq || [];
+    tracker.push(['trackEvent', 'Duck', 'Click', `Total click ${this.totalClicks}`, this.totalClicks]);
   }
 
   trackClicks() {

--- a/src/assets/js/components/tdc-speaker-modal.js
+++ b/src/assets/js/components/tdc-speaker-modal.js
@@ -64,11 +64,12 @@ class TdcSpeakerModal {
     const talkTitle = button.getAttribute("data-speaker-talk-title") || "";
     const talkDescription = button.getAttribute("data-speaker-talk-description") || "";
 
-    // Record every profile open as a named event so Matomo can show which
+    // Record every profile click as a named event so Matomo can show which
     // speakers get the most interest. The queue also works before Matomo's
-    // script has finished loading.
+    // script has finished loading. The Sessionize ID remains in the markup
+    // for stable client-side identification if a speaker's display name changes.
     const tracker = window._paq = window._paq || [];
-    tracker.push(["trackEvent", "Speakers", "Open profile", name]);
+    tracker.push(["trackEvent", "Speakers", "Click", name, 1]);
 
     this.nameEl.textContent = name;
     this.avatarEl.src = image;

--- a/src/tests/smoke.spec.ts
+++ b/src/tests/smoke.spec.ts
@@ -184,8 +184,53 @@ test.describe('Duck mascot', () => {
       await duck.dispatchEvent('click');
     }
 
-    await expect(dLetters.first()).toHaveText('Duck');
-    await expect(dLetters.first()).toHaveClass(/is-tduckc/);
+    await expect(dLetters.first()).toHaveText('Duck', { timeout: 10000 });
+    await expect(dLetters.first()).toHaveClass(/is-tduckc/, { timeout: 10000 });
     await expect(page.locator('.tdc-wordmark.is-tduckc')).toHaveCount(2);
+  });
+
+  test('tracks each click with its cumulative total', async ({ page }) => {
+    await page.route('**stats.trondheimdc.no/**', (route) => route.abort());
+    await page.goto('/');
+
+    const duck = page.locator('#hero tdc-duck .duck');
+    await duck.dispatchEvent('click');
+    await duck.dispatchEvent('click');
+
+    const events = await page.evaluate(() =>
+      ((window as Window & { _paq?: unknown[][] })._paq || []).filter(
+        (entry) => entry[0] === 'trackEvent' && entry[1] === 'Duck',
+      ),
+    );
+
+    expect(events).toEqual([
+      ['trackEvent', 'Duck', 'Click', 'Total click 1', 1],
+      ['trackEvent', 'Duck', 'Click', 'Total click 2', 2],
+    ]);
+  });
+});
+
+test.describe('Speaker analytics', () => {
+  test('tracks the clicked speaker by name', async ({ page }) => {
+    await page.route('**stats.trondheimdc.no/**', (route) => route.abort());
+    await page.goto('/');
+
+    const speaker = page.locator('[data-speaker-open]').first();
+    await expect(speaker).toBeVisible();
+    const name = await speaker.getAttribute('data-speaker-name');
+    await speaker.dispatchEvent('click');
+
+    const event = await page.evaluate((speakerName) =>
+      ((window as Window & { _paq?: unknown[][] })._paq || []).find(
+        (entry) =>
+          entry[0] === 'trackEvent' &&
+          entry[1] === 'Speakers' &&
+          entry[2] === 'Click' &&
+          entry[3] === speakerName,
+      ),
+      name,
+    );
+
+    expect(event).toEqual(['trackEvent', 'Speakers', 'Click', name, 1]);
   });
 });


### PR DESCRIPTION
## Summary
- Track every duck activation (mouse and keyboard) as a Matomo Duck / Click event.
- Include the cumulative click number as the event name (Total click N) and numeric value, so reports show distributions such as click 1 occurring five times and click 2 occurring three times.
- Track every speaker profile click as a Matomo Speakers / Click event named for the speaker.
- Add stable Sessionize speaker IDs to speaker card markup.
- Add Playwright coverage for both analytics event types.

## Verification
- un run build ✅
- 
px playwright test — 20 passed ✅
- get_errors — no errors in changed JS/TS files ✅