### PR TITLE
Fix background scroll while modal is open

### DIFF
--- a/src/assets/css/01-base/reset.css
+++ b/src/assets/css/01-base/reset.css
@@ -30,6 +30,11 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+/* Keep background content stationary while a dialog owns the scroll. */
+body.modal-open {
+  overflow: hidden;
+}
+
 /* Media defaults */
 img,
 picture,

--- a/src/assets/js/components/modal-scroll-lock.js
+++ b/src/assets/js/components/modal-scroll-lock.js
@@ -1,0 +1,10 @@
+const MODAL_OPEN_CLASS = "modal-open";
+
+export function lockModalScroll() {
+  document.body.classList.add(MODAL_OPEN_CLASS);
+}
+
+export function unlockModalScroll() {
+  if (document.querySelector("dialog[open]")) return;
+  document.body.classList.remove(MODAL_OPEN_CLASS);
+}

--- a/src/assets/js/components/tdc-program-modal.js
+++ b/src/assets/js/components/tdc-program-modal.js
@@ -1,3 +1,5 @@
+import { lockModalScroll, unlockModalScroll } from "./modal-scroll-lock.js";
+
 class TdcProgramModal {
   constructor() {
     this.dialog = document.getElementById("program-description-modal");
@@ -31,6 +33,8 @@ class TdcProgramModal {
         this.dialog.close();
       }
     });
+
+    this.dialog.addEventListener("close", unlockModalScroll);
   }
 
   open(button) {
@@ -45,6 +49,8 @@ class TdcProgramModal {
     } else {
       this.dialog.setAttribute("open", "");
     }
+
+    lockModalScroll();
   }
 }
 

--- a/src/assets/js/components/tdc-speaker-modal.js
+++ b/src/assets/js/components/tdc-speaker-modal.js
@@ -1,5 +1,6 @@
 // Speaker detail modal — populates the dialog with the clicked speaker's
 // bio and talk info (both always visible), plus their social links.
+import { lockModalScroll, unlockModalScroll } from "./modal-scroll-lock.js";
 
 class TdcSpeakerModal {
   constructor() {
@@ -51,6 +52,8 @@ class TdcSpeakerModal {
         this.dialog.close();
       }
     });
+
+    this.dialog.addEventListener("close", unlockModalScroll);
   }
 
   open(button) {
@@ -86,6 +89,8 @@ class TdcSpeakerModal {
     } else {
       this.dialog.setAttribute("open", "");
     }
+
+    lockModalScroll();
   }
 
   buildSocialLinks(twitter, linkedIn, blog) {

--- a/src/tests/smoke.spec.ts
+++ b/src/tests/smoke.spec.ts
@@ -233,4 +233,14 @@ test.describe('Speaker analytics', () => {
 
     expect(event).toEqual(['trackEvent', 'Speakers', 'Click', name, 1]);
   });
+
+  test('locks page scroll while the speaker modal is open', async ({ page }) => {
+    await page.goto('/');
+
+    await page.locator('[data-speaker-open]').first().click();
+    await expect(page.locator('body')).toHaveClass(/modal-open/);
+
+    await page.locator('[data-speaker-close]').click();
+    await expect(page.locator('body')).not.toHaveClass(/modal-open/);
+  });
 });


### PR DESCRIPTION
## Summary

Prevent the page behind speaker and program dialogs from scrolling while the modal's content scrolls.

## Changes

- Add a shared modal scroll-lock helper.
- Apply and remove the modal-open body class through each dialog's lifecycle.
- Add a Playwright regression test covering the speaker modal.

## Verification

- un run build passes.
- Playwright smoke suite passes: 21/21 tests.