### PR TITLE
Add Sessionize program embed before speakers

### DIFF
--- a/src/_includes/partials/nav.njk
+++ b/src/_includes/partials/nav.njk
@@ -22,6 +22,7 @@
         <ul class="site-nav__links" role="list">
           <li><a href="#about" class="site-nav__link" data-section="about">{{ t.nav.about }}</a></li>
           <li><a href="#tickets" class="site-nav__link" data-section="tickets">{{ t.nav.tickets }}</a></li>
+          <li><a href="#program" class="site-nav__link" data-section="program">{{ t.nav.program }}</a></li>
           <li><a href="#speakers" class="site-nav__link" data-section="speakers">{{ t.nav.speakers }}</a></li>
           <li><a href="#partner" class="site-nav__link" data-section="partner">{{ t.nav.partners }}</a></li>
           <li><a href="#faq" class="site-nav__link" data-section="faq">{{ t.nav.faq }}</a></li>

--- a/src/_includes/sections/program.njk
+++ b/src/_includes/sections/program.njk
@@ -5,77 +5,8 @@
       <h2 class="section__title text-h1" id="program-title">{{ t.program.title }}</h2>
     </header>
 
-    {# Custom program schedule using Sessionize API data #}
-    <div class="program-schedule">
-      {% if sessionize.sessions and sessionize.sessions.length > 0 %}
-        <div class="sessions-grid">
-          {% for session in sessionize.sessions %}
-            <article class="session-card" data-session-id="{{ session.id }}">
-              <div class="session-card__header">
-                <h3 class="session-card__title">{{ session.title }}</h3>
-                {% if session.startsAt %}
-                  <time class="session-card__time" datetime="{{ session.startsAt }}">
-                    {{ session.startsAt | isoTime }}
-                  </time>
-                {% endif %}
-              </div>
-
-              {% if session.description %}
-                <button
-                  type="button"
-                  class="session-card__details-button"
-                  data-session-open
-                  data-session-title="{{ session.title | escape }}"
-                  data-session-description="{{ session.description | escape }}"
-                >
-                  {% if lang == "en" %}
-                    Show description
-                  {% else %}
-                    Vis beskrivelse
-                  {% endif %}
-                </button>
-              {% endif %}
-
-              {% if session.speakers and session.speakers.length > 0 %}
-                <div class="session-card__speakers">
-                  {% for speakerId in session.speakers %}
-                    {% set speaker = sessionize.speakers | speakerById(speakerId) %}
-                    {% if speaker %}
-                      <a href="#speaker-{{ speaker.id }}" class="speaker-link">
-                        <img 
-                          src="{{ speaker.profilePicture }}" 
-                          alt="{{ speaker.firstName }} {{ speaker.lastName }}"
-                          class="speaker-link__avatar"
-                        />
-                        <span class="speaker-link__name">{{ speaker.firstName }} {{ speaker.lastName }}</span>
-                      </a>
-                    {% endif %}
-                  {% endfor %}
-                </div>
-              {% endif %}
-
-              {% if session.roomId %}
-                {% set room = sessionize.rooms | roomById(session.roomId) %}
-                {% if room %}
-                  <div class="session-card__room">
-                    📍 {{ room.name }}
-                  </div>
-                {% endif %}
-              {% endif %}
-            </article>
-          {% endfor %}
-        </div>
-
-        <dialog class="program-modal" id="program-description-modal" aria-labelledby="program-modal-title">
-          <div class="program-modal__header">
-            <h3 class="program-modal__title" id="program-modal-title"></h3>
-            <button type="button" class="program-modal__close" data-session-close aria-label="Close">✕</button>
-          </div>
-          <div class="program-modal__body" id="program-modal-body"></div>
-        </dialog>
-      {% else %}
-        <p class="section__lead text-lead">{{ t.program.placeholder }}</p>
-      {% endif %}
+    <div class="program-embed" aria-label="{{ t.program.title }}">
+      <script type="text/javascript" src="https://sessionize.com/api/v2/xx320rm2/view/GridSmart"></script>
     </div>
   </div>
 </section>

--- a/src/_layouts/home.njk
+++ b/src/_layouts/home.njk
@@ -8,8 +8,7 @@ layout: default.njk
 {% include "sections/hero.njk" %}
 {% include "sections/about.njk" %}
 {% include "sections/tickets.njk" %}
-{# Program is hidden until the agenda is published — see issue #89.
-   {% include "sections/program.njk" %} #}
+{% include "sections/program.njk" %}
 {% include "sections/speakers.njk" %}
 {% include "sections/partner.njk" %}
 {% include "sections/faq.njk" %}

--- a/src/assets/css/04-components/nav.css
+++ b/src/assets/css/04-components/nav.css
@@ -9,7 +9,8 @@
 .site-nav {
   position: sticky;
   inset-block-start: 0;
-  z-index: 100;
+  z-index: 1000;
+  isolation: isolate;
   background-color: color-mix(in srgb, var(--color-bg-base) 82%, transparent);
   backdrop-filter: blur(8px);
   border-block-end: 1px solid transparent;

--- a/src/assets/css/04-components/program-sessionize.css
+++ b/src/assets/css/04-components/program-sessionize.css
@@ -1,4 +1,6 @@
-/* Sessionize-driven program layout */
+/* Sessionize owns the embedded schedule layout. Keep this file for the
+   legacy program component styles below; do not override the embed's grid. */
+
 .program-schedule {
   display: block;
 }

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -2,7 +2,6 @@
 import "./components/tdc-nav.js";
 import "./components/tdc-section.js";
 import "./components/tdc-theme-toggle.js";
-import "./components/tdc-program-modal.js";
 import "./components/tdc-speaker-modal.js";
 import "./components/tdc-faq.js";
 // Clickable 8-bit duck mascot + easter eggs (lazy-loads the duck-mate engine).

--- a/src/en/program/index.njk
+++ b/src/en/program/index.njk
@@ -6,12 +6,12 @@ eleventyExcludeFromCollections: true
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=/en/#program">
+    <meta http-equiv="refresh" content="0; url={{ '/en/' | url }}#program">
     <meta name="robots" content="noindex, nofollow">
     <title>Program — TDC 2026</title>
-    <script>location.replace('/en/#program');</script>
+    <script>location.replace({{ ('/en/' | url) | dump }} + '#program');</script>
   </head>
   <body>
-    <p><a href="/en/#program">Go to the program</a></p>
+    <p><a href="{{ '/en/' | url }}#program">Go to the program</a></p>
   </body>
 </html>

--- a/src/program/index.njk
+++ b/src/program/index.njk
@@ -6,12 +6,12 @@ eleventyExcludeFromCollections: true
 <html lang="no">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=/#program">
+    <meta http-equiv="refresh" content="0; url={{ '/' | url }}#program">
     <meta name="robots" content="noindex, nofollow">
     <title>Program — TDC 2026</title>
-    <script>location.replace('/#program');</script>
+    <script>location.replace({{ ('/' | url) | dump }} + '#program');</script>
   </head>
   <body>
-    <p><a href="/#program">Gå til programmet</a></p>
+    <p><a href="{{ '/' | url }}#program">Gå til programmet</a></p>
   </body>
 </html>

--- a/src/tests/smoke.spec.ts
+++ b/src/tests/smoke.spec.ts
@@ -10,12 +10,12 @@ import { test, expect } from '@playwright/test';
  * that the parked easter eggs never load.
  */
 
-// Sections rendered on the single-page layout (home.njk). "program" and "cfp"
-// are intentionally not listed: the agenda isn't published yet and the CFP is
-// closed, so both includes are commented out in home.njk.
+// Sections rendered on the single-page layout (home.njk). The program embed is
+// placed immediately before the speaker area.
 const SECTION_IDS = [
   'about',
   'tickets',
+  'program',
   'speakers',
   'partner',
   'faq',
@@ -23,7 +23,7 @@ const SECTION_IDS = [
   'coc',
 ];
 
-const NAV_SECTIONS = ['about', 'tickets', 'speakers', 'partner', 'faq', 'coc'];
+const NAV_SECTIONS = ['about', 'tickets', 'program', 'speakers', 'partner', 'faq', 'coc'];
 
 test.describe('Pages load', () => {
   for (const path of ['/', '/en/']) {
@@ -36,6 +36,23 @@ test.describe('Pages load', () => {
       await page.goto(path);
       await expect(page).toHaveTitle(/TDC/);
     });
+
+    test(`${path} uses the Sessionize GridSmart embed`, async ({ page }) => {
+      await page.goto(path);
+      await expect(
+        page.locator('#program script[src="https://sessionize.com/api/v2/xx320rm2/view/GridSmart"]'),
+      ).toHaveCount(1);
+    });
+
+    test(`${path} places the program directly before speakers`, async ({ page }) => {
+      await page.goto(path);
+      const order = await page.locator('main > tdc-section > section').evaluateAll((sections) =>
+        sections.map((section) => section.id),
+      );
+
+      expect(order.indexOf('program')).toBe(order.indexOf('speakers') - 1);
+    });
+
   }
 });
 


### PR DESCRIPTION
## Summary
- add the official Sessionize GridSmart embed to the homepage program section
- place the program section and navigation link directly before speakers
- remove the custom program renderer and modal from the active page
- keep legacy program redirects path-prefix aware
- retain smoke coverage for the embed and section ordering

## Verification
- un run build from src/
- diagnostics clean for the changed CSS and smoke tests
- Playwright smoke suite: 23 passed; one title-navigation test timed out once while the preview server was restarting, then the remaining suite passed

## Notes
- Sessionize owns its embedded layout and responsive behavior for now; custom margin/grid corrections were intentionally reverted for later iteration.